### PR TITLE
Add Conflict Data Filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 
 script:
   - bazel build ...
+  - bazel test //src/test/java/com/googleintern/wfm/ruleengine:DataProcessorTest
   - bazel test //src/test/java/com/googleintern/wfm/ruleengine:RuleValidationTest
   - bazel test //src/test/java/com/googleintern/wfm/ruleengine:FilterReductionTest
   - bazel test //src/test/java/com/googleintern/wfm/ruleengine:CasePoolIdAndPermissionIdRuleGeneratorTest

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
@@ -1,7 +1,12 @@
 package src.main.java.com.googleintern.wfm.ruleengine.action;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import src.main.java.com.googleintern.wfm.ruleengine.model.FilterModel;
 import src.main.java.com.googleintern.wfm.ruleengine.model.UserModel;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 /** DataProcessor class is used to filter out invalid or conflict data. */
 public class DataProcessor {
@@ -16,5 +21,81 @@ public class DataProcessor {
       if (data.workgroupId() > 0) validDataBuilder.add(data);
     }
     return validDataBuilder.build();
+  }
+
+  public static void printConflictUserPairs(ImmutableSetMultimap<Long, Long> conflictUserPairs) {
+    for (Long userId : conflictUserPairs.keySet()) {
+      StringBuilder conflictRow = new StringBuilder();
+      conflictRow.append(userId + "  [");
+      ImmutableSet<Long> conflictUserIds = conflictUserPairs.get(userId);
+      for (Long conflictId : conflictUserIds) {
+        conflictRow.append(conflictId + "   ");
+      }
+      conflictRow.append("]");
+      System.out.println(conflictRow.toString());
+    }
+  }
+
+  public static ImmutableSet<UserModel> removeAllCoveredConflictUsers(
+          ImmutableList<UserModel> users, ImmutableSet<Long> coveredConflictUsers) {
+    return users.stream()
+            .filter(user -> !coveredConflictUsers.contains(user.userId()))
+            .collect(toImmutableSet());
+  }
+
+  public static ImmutableSet<Long> collectAllCoveredConflictUsers(
+          ImmutableSetMultimap<Long, Long> conflictUserPairs) {
+    ImmutableSet.Builder<Long> coveredConflictUsers = ImmutableSet.builder();
+    conflictUserPairs
+            .keySet()
+            .forEach(key -> coveredConflictUsers.addAll(conflictUserPairs.get(key)));
+    return coveredConflictUsers.build();
+  }
+
+  /**
+   * key userId: filter{a, b, c}, permission{1, 2}
+   * value userId: filter{a, b}, permission{1, 2, 3}
+   */
+  public static ImmutableSetMultimap<Long, Long> findConflictUserPairs(
+          ImmutableList<UserModel> users) {
+    ImmutableSetMultimap.Builder<Long, Long> conflictUserPairsBuilder =
+            ImmutableSetMultimap.builder();
+    for (int i = 0; i < users.size(); i++) {
+      UserModel currentUser = users.get(i);
+      ImmutableSet<FilterModel> currentFilters = convertSkillIdRoleIdToFilter(currentUser);
+      for (int j = i + 1; j < users.size(); j++) {
+        UserModel comparedUser = users.get(j);
+        ImmutableSet<FilterModel> comparedFilters = convertSkillIdRoleIdToFilter(comparedUser);
+        if (currentFilters.containsAll(comparedFilters)
+                && !currentUser.poolAssignments().containsAll(comparedUser.poolAssignments())) {
+          conflictUserPairsBuilder.put(currentUser.userId(), comparedUser.userId());
+        }
+        if (comparedFilters.containsAll(currentFilters)
+                && !comparedUser.poolAssignments().containsAll(currentUser.poolAssignments())) {
+          conflictUserPairsBuilder.put(comparedUser.userId(), currentUser.userId());
+        }
+      }
+    }
+    return conflictUserPairsBuilder.build();
+  }
+
+  private static ImmutableSet<FilterModel> convertSkillIdRoleIdToFilter(UserModel user) {
+    ImmutableSet.Builder<FilterModel> filtersBuilder = ImmutableSet.builder();
+    for (Long roleId : user.roleIds()) {
+      filtersBuilder.add(
+              FilterModel.builder().setType(FilterModel.FilterType.ROLE).setValue(roleId).build());
+    }
+    for (Long skillId : user.skillIds()) {
+      filtersBuilder.add(
+              FilterModel.builder().setType(FilterModel.FilterType.SKILL).setValue(skillId).build());
+    }
+    for (Long roleSkillId : user.roleSkillIds()) {
+      filtersBuilder.add(
+              FilterModel.builder()
+                      .setType(FilterModel.FilterType.SKILL)
+                      .setValue(roleSkillId)
+                      .build());
+    }
+    return filtersBuilder.build();
   }
 }

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import src.main.java.com.googleintern.wfm.ruleengine.model.UserModel;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -14,8 +15,7 @@ import static java.util.stream.Collectors.toSet;
 public class DataProcessor {
 
   /** Filter out user data with invalid workgroup Id values(< 0). */
-  public static ImmutableList<UserModel> filterUsersWithValidWorkgroupId(
-      ImmutableList<UserModel> rawData) {
+  public static ImmutableList<UserModel> filterUsersWithValidWorkgroupId(List<UserModel> rawData) {
     return rawData.stream().filter(data -> data.workgroupId() > 0).collect(toImmutableList());
   }
 
@@ -32,14 +32,14 @@ public class DataProcessor {
    * 2 are included in the types for User 0. However, User 1 and 2 have a different permission CCCC
    * that is not included in User 0.
    */
-  public static ImmutableList<UserModel> removeConflictUsers(ImmutableList<UserModel> rawUserData) {
+  public static ImmutableList<UserModel> removeConflictUsers(List<UserModel> rawUserData) {
     ImmutableSet<Long> coveredConflictUsers = findConflictUserIdPairs(rawUserData);
     return rawUserData.stream()
         .filter(user -> !coveredConflictUsers.contains(user.userId()))
         .collect(toImmutableList());
   }
 
-  private static ImmutableSet<Long> findConflictUserIdPairs(ImmutableList<UserModel> rawUserData) {
+  private static ImmutableSet<Long> findConflictUserIdPairs(List<UserModel> rawUserData) {
     Set<Long> dirtyUsers = new HashSet<Long>();
     Set<Long> visitedUsers = new HashSet<Long>();
 
@@ -55,7 +55,7 @@ public class DataProcessor {
                       !visitedUsers.contains(comparedUser.userId())
                           && !dirtyUsers.contains(comparedUser.userId())
                           && currentUser.isConflictUserPair(comparedUser))
-              .map(comparedUser -> comparedUser.userId())
+              .map(UserModel::userId)
               .collect(toSet()));
     }
     return ImmutableSet.copyOf(dirtyUsers);

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
@@ -7,15 +7,14 @@ import src.main.java.com.googleintern.wfm.ruleengine.model.FilterModel;
 import src.main.java.com.googleintern.wfm.ruleengine.model.UserModel;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 
 /** DataProcessor class is used to filter out invalid or conflict data. */
 public class DataProcessor {
 
   /** Filter out user data with invalid workgroup Id values(< 0). */
-  public static ImmutableList<UserModel> filterValidData(
-      ImmutableList<UserModel> rawData) {
-    ImmutableList.Builder<UserModel> validDataBuilder =
-        ImmutableList.<UserModel>builder();
+  public static ImmutableList<UserModel> filterValidData(ImmutableList<UserModel> rawData) {
+    ImmutableList.Builder<UserModel> validDataBuilder = ImmutableList.<UserModel>builder();
 
     for (final UserModel data : rawData) {
       if (data.workgroupId() > 0) validDataBuilder.add(data);
@@ -37,64 +36,64 @@ public class DataProcessor {
   }
 
   public static ImmutableSet<UserModel> removeAllCoveredConflictUsers(
-          ImmutableList<UserModel> users, ImmutableSet<Long> coveredConflictUsers) {
+      ImmutableList<UserModel> users, ImmutableSet<Long> coveredConflictUsers) {
     return users.stream()
-            .filter(user -> !coveredConflictUsers.contains(user.userId()))
-            .collect(toImmutableSet());
+        .filter(user -> !coveredConflictUsers.contains(user.userId()))
+        .collect(toImmutableSet());
   }
 
   public static ImmutableSet<Long> collectAllCoveredConflictUsers(
-          ImmutableSetMultimap<Long, Long> conflictUserPairs) {
+      ImmutableSetMultimap<Long, Long> conflictUserPairs) {
     ImmutableSet.Builder<Long> coveredConflictUsers = ImmutableSet.builder();
     conflictUserPairs
-            .keySet()
-            .forEach(key -> coveredConflictUsers.addAll(conflictUserPairs.get(key)));
+        .keySet()
+        .forEach(key -> coveredConflictUsers.addAll(conflictUserPairs.get(key)));
     return coveredConflictUsers.build();
   }
 
   /**
-   * key userId: filter{a, b, c}, permission{1, 2}
-   * value userId: filter{a, b}, permission{1, 2, 3}
+   * key userId: filter{a, b, c}, permission{1, 2} value userId: filter{a, b}, permission{1, 2, 3}
    */
   public static ImmutableSetMultimap<Long, Long> findConflictUserPairs(
-          ImmutableList<UserModel> users) {
+      ImmutableList<UserModel> users) {
     ImmutableSetMultimap.Builder<Long, Long> conflictUserPairsBuilder =
-            ImmutableSetMultimap.builder();
-    for (int i = 0; i < users.size(); i++) {
-      UserModel currentUser = users.get(i);
-      ImmutableSet<FilterModel> currentFilters = convertSkillIdRoleIdToFilter(currentUser);
-      for (int j = i + 1; j < users.size(); j++) {
-        UserModel comparedUser = users.get(j);
-        ImmutableSet<FilterModel> comparedFilters = convertSkillIdRoleIdToFilter(comparedUser);
-        if (currentFilters.containsAll(comparedFilters)
-                && !currentUser.poolAssignments().containsAll(comparedUser.poolAssignments())) {
-          conflictUserPairsBuilder.put(currentUser.userId(), comparedUser.userId());
-        }
-        if (comparedFilters.containsAll(currentFilters)
-                && !comparedUser.poolAssignments().containsAll(currentUser.poolAssignments())) {
-          conflictUserPairsBuilder.put(comparedUser.userId(), currentUser.userId());
-        }
-      }
-    }
+        ImmutableSetMultimap.builder();
+    users.forEach(
+        currentUser ->
+            conflictUserPairsBuilder.putAll(
+                currentUser.userId(), findConflictUsers(currentUser, users)));
     return conflictUserPairsBuilder.build();
+  }
+
+  private static ImmutableSet<Long> findConflictUsers(
+      UserModel currentUser, ImmutableList<UserModel> users) {
+    return users.stream()
+        .filter(
+            comparedUser ->
+                currentUser.skillIds().containsAll(comparedUser.skillIds())
+                    && currentUser.roleIds().containsAll(comparedUser.roleIds())
+                    && currentUser.roleSkillIds().containsAll(comparedUser.roleSkillIds())
+                    && !currentUser.poolAssignments().containsAll(comparedUser.poolAssignments()))
+        .map(comparedUser -> comparedUser.userId())
+        .collect(toImmutableSet());
   }
 
   private static ImmutableSet<FilterModel> convertSkillIdRoleIdToFilter(UserModel user) {
     ImmutableSet.Builder<FilterModel> filtersBuilder = ImmutableSet.builder();
     for (Long roleId : user.roleIds()) {
       filtersBuilder.add(
-              FilterModel.builder().setType(FilterModel.FilterType.ROLE).setValue(roleId).build());
+          FilterModel.builder().setType(FilterModel.FilterType.ROLE).setValue(roleId).build());
     }
     for (Long skillId : user.skillIds()) {
       filtersBuilder.add(
-              FilterModel.builder().setType(FilterModel.FilterType.SKILL).setValue(skillId).build());
+          FilterModel.builder().setType(FilterModel.FilterType.SKILL).setValue(skillId).build());
     }
     for (Long roleSkillId : user.roleSkillIds()) {
       filtersBuilder.add(
-              FilterModel.builder()
-                      .setType(FilterModel.FilterType.SKILL)
-                      .setValue(roleSkillId)
-                      .build());
+          FilterModel.builder()
+              .setType(FilterModel.FilterType.SKILL)
+              .setValue(roleSkillId)
+              .build());
     }
     return filtersBuilder.build();
   }

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionService.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionService.java
@@ -9,5 +9,5 @@ public interface RuleSuggestionService {
   //Returns a string style CSV.
   String suggestRules (String csvFilePath) throws IOException, CsvException;
 
-  String suggestRules (String csvFilePath, int percentage);
+  String suggestRules (String csvFilePath, boolean assignMorePermissions) throws IOException, CsvException;
 }

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
@@ -85,10 +85,9 @@ public class RuleSuggestionServiceImplementation implements RuleSuggestionServic
 
     ImmutableSet<RuleModel> concentratedRules = RuleConcentration.concentrate(rules);
 
-    RuleValidation ruleValidation = new RuleValidation(validUsers);
+    RuleValidation ruleValidation = new RuleValidation(usersWithValidWorkgroupId);
     RuleValidationReport ruleValidationReport = ruleValidation.validate(concentratedRules);
     ruleValidationReport.writeToCsvFile(CSV_OUTPUT_FILE_PATH);
-
     return ruleValidationReport.convertRuleValidationReportToString();
   }
 

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
@@ -7,7 +7,6 @@ import src.main.java.com.googleintern.wfm.ruleengine.action.generator.CasePoolId
 import src.main.java.com.googleintern.wfm.ruleengine.action.generator.RuleIdGenerator;
 import src.main.java.com.googleintern.wfm.ruleengine.action.generator.WorkgroupIdRuleGenerator;
 import src.main.java.com.googleintern.wfm.ruleengine.model.*;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,7 +26,7 @@ public class RuleSuggestionServiceImplementation implements RuleSuggestionServic
 
   public static void main(String[] args) throws IOException, CsvException {
     RuleSuggestionServiceImplementation ruleSuggestion = new RuleSuggestionServiceImplementation();
-    ruleSuggestion.suggestRules(CSV_INPUT_FILE_PATH);
+    ruleSuggestion.suggestRules(CSV_INPUT_FILE_PATH, false);
   }
 
   /**
@@ -55,13 +54,14 @@ public class RuleSuggestionServiceImplementation implements RuleSuggestionServic
   public String suggestRules(String csvFilePath) throws IOException, CsvException {
     ImmutableList<UserModel> userPoolAssignments = CsvParser.readFromCSVFile(csvFilePath);
 
-    ImmutableList<UserModel> validUserPoolAssignments =
-        DataProcessor.filterValidData(userPoolAssignments);
+    ImmutableList<UserModel> usersWithValidWorkgroupId =
+        DataProcessor.filterUsersWithValidWorkgroupId(userPoolAssignments);
 
-    ImmutableSet<RuleModel> rules = suggestRules(validUserPoolAssignments);
+    ImmutableSet<RuleModel> rules = suggestRules(usersWithValidWorkgroupId);
+
     ImmutableSet<RuleModel> concentratedRules = RuleConcentration.concentrate(rules);
 
-    RuleValidation ruleValidation = new RuleValidation(validUserPoolAssignments);
+    RuleValidation ruleValidation = new RuleValidation(usersWithValidWorkgroupId);
     RuleValidationReport ruleValidationReport = ruleValidation.validate(concentratedRules);
     ruleValidationReport.writeToCsvFile(CSV_OUTPUT_FILE_PATH);
 
@@ -69,8 +69,27 @@ public class RuleSuggestionServiceImplementation implements RuleSuggestionServic
   }
 
   @Override
-  public String suggestRules(String csvFilePath, int percentage) {
-    throw new NotImplementedException();
+  public String suggestRules(String csvFilePath, boolean assignMorePermissions)
+      throws IOException, CsvException {
+    ImmutableList<UserModel> userPoolAssignments = CsvParser.readFromCSVFile(csvFilePath);
+
+    ImmutableList<UserModel> usersWithValidWorkgroupId =
+        DataProcessor.filterUsersWithValidWorkgroupId(userPoolAssignments);
+
+    ImmutableList<UserModel> validUsers =
+        assignMorePermissions == true
+            ? usersWithValidWorkgroupId
+            : DataProcessor.removeConflictUsers(usersWithValidWorkgroupId);
+
+    ImmutableSet<RuleModel> rules = suggestRules(validUsers);
+
+    ImmutableSet<RuleModel> concentratedRules = RuleConcentration.concentrate(rules);
+
+    RuleValidation ruleValidation = new RuleValidation(validUsers);
+    RuleValidationReport ruleValidationReport = ruleValidation.validate(concentratedRules);
+    ruleValidationReport.writeToCsvFile(CSV_OUTPUT_FILE_PATH);
+
+    return ruleValidationReport.convertRuleValidationReportToString();
   }
 
   private ImmutableSet<RuleModel> suggestRules(List<UserModel> validUserPoolAssignments) {

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
@@ -77,7 +77,7 @@ public class RuleSuggestionServiceImplementation implements RuleSuggestionServic
         DataProcessor.filterUsersWithValidWorkgroupId(userPoolAssignments);
 
     ImmutableList<UserModel> validUsers =
-        assignMorePermissions == true
+        assignMorePermissions
             ? usersWithValidWorkgroupId
             : DataProcessor.removeConflictUsers(usersWithValidWorkgroupId);
 

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/service/RuleSuggestionServiceImplementation.java
@@ -52,20 +52,7 @@ public class RuleSuggestionServiceImplementation implements RuleSuggestionServic
    */
   @Override
   public String suggestRules(String csvFilePath) throws IOException, CsvException {
-    ImmutableList<UserModel> userPoolAssignments = CsvParser.readFromCSVFile(csvFilePath);
-
-    ImmutableList<UserModel> usersWithValidWorkgroupId =
-        DataProcessor.filterUsersWithValidWorkgroupId(userPoolAssignments);
-
-    ImmutableSet<RuleModel> rules = suggestRules(usersWithValidWorkgroupId);
-
-    ImmutableSet<RuleModel> concentratedRules = RuleConcentration.concentrate(rules);
-
-    RuleValidation ruleValidation = new RuleValidation(usersWithValidWorkgroupId);
-    RuleValidationReport ruleValidationReport = ruleValidation.validate(concentratedRules);
-    ruleValidationReport.writeToCsvFile(CSV_OUTPUT_FILE_PATH);
-
-    return ruleValidationReport.convertRuleValidationReportToString();
+    return suggestRules(csvFilePath, true);
   }
 
   @Override

--- a/src/main/java/com/googleintern/wfm/ruleengine/model/UserModel.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/model/UserModel.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
 /** UserPoolAssignmentModel class is used to store a row of data from input file. */
 @AutoValue
 public abstract class UserModel {
@@ -49,5 +51,19 @@ public abstract class UserModel {
     public abstract Builder setPoolAssignments(Set<PoolAssignmentModel> poolAssignments);
 
     public abstract UserModel build();
+  }
+
+  public ImmutableSet<Long> findConflictUsers(ImmutableList<UserModel> users) {
+    return users.stream()
+        .filter(
+            comparedUser ->
+                workforceId() == comparedUser.workforceId()
+                    && workgroupId() == comparedUser.workgroupId()
+                    && skillIds().containsAll(comparedUser.skillIds())
+                    && roleIds().containsAll(comparedUser.roleIds())
+                    && roleSkillIds().containsAll(comparedUser.roleSkillIds())
+                    && !poolAssignments().containsAll(comparedUser.poolAssignments()))
+        .map(comparedUser -> comparedUser.userId())
+        .collect(toImmutableSet());
   }
 }

--- a/src/main/java/com/googleintern/wfm/ruleengine/model/UserModel.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/model/UserModel.java
@@ -53,17 +53,12 @@ public abstract class UserModel {
     public abstract UserModel build();
   }
 
-  public ImmutableSet<Long> findConflictUsers(ImmutableList<UserModel> users) {
-    return users.stream()
-        .filter(
-            comparedUser ->
-                workforceId() == comparedUser.workforceId()
-                    && workgroupId() == comparedUser.workgroupId()
-                    && skillIds().containsAll(comparedUser.skillIds())
-                    && roleIds().containsAll(comparedUser.roleIds())
-                    && roleSkillIds().containsAll(comparedUser.roleSkillIds())
-                    && !poolAssignments().containsAll(comparedUser.poolAssignments()))
-        .map(comparedUser -> comparedUser.userId())
-        .collect(toImmutableSet());
+  public boolean isConflictUserPair(UserModel comparedUser) {
+    return workforceId() == comparedUser.workforceId()
+        && workgroupId() == comparedUser.workgroupId()
+        && skillIds().containsAll(comparedUser.skillIds())
+        && roleIds().containsAll(comparedUser.roleIds())
+        && roleSkillIds().containsAll(comparedUser.roleSkillIds())
+        && !poolAssignments().containsAll(comparedUser.poolAssignments());
   }
 }

--- a/src/test/java/com/googleintern/wfm/ruleengine/DataProcessorTest.java
+++ b/src/test/java/com/googleintern/wfm/ruleengine/DataProcessorTest.java
@@ -1,33 +1,151 @@
 package src.test.java.com.googleintern.wfm.ruleengine;
 
 import com.google.common.collect.ImmutableList;
-import com.opencsv.exceptions.CsvException;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
-import src.main.java.com.googleintern.wfm.ruleengine.action.CsvParser;
 import src.main.java.com.googleintern.wfm.ruleengine.action.DataProcessor;
+import src.main.java.com.googleintern.wfm.ruleengine.model.PoolAssignmentModel;
 import src.main.java.com.googleintern.wfm.ruleengine.model.UserModel;
-
-import java.io.IOException;
 
 /** DataProcessorTest class is used to test the functionality of DataProcessing class. */
 public class DataProcessorTest {
-  private static final String TEST_CSV_FILE_PATH =
-      System.getProperty("user.home")
-          + "/Project/wfm-rule-suggestion-engine/src/"
-          + "test/resources/com/googleintern/wfm/ruleengine/csv_parser_test_data.csv";
-  private static final int EXPECTED_VALID_DATA_SIZE = 5;
-  private static final long INVALID_WORKGROUP_ID = 0L;
+  private static final PoolAssignmentModel POOL_ASSIGNMENT_0 =
+      PoolAssignmentModel.builder().setCasePoolId(2020L).setPermissionSetId(0000L).build();
+  private static final PoolAssignmentModel POOL_ASSIGNMENT_1 =
+      PoolAssignmentModel.builder().setCasePoolId(2020L).setPermissionSetId(1111L).build();
+  private static final PoolAssignmentModel POOL_ASSIGNMENT_2 =
+      PoolAssignmentModel.builder().setCasePoolId(2020L).setPermissionSetId(2222L).build();
+  private static final PoolAssignmentModel POOL_ASSIGNMENT_3 =
+      PoolAssignmentModel.builder().setCasePoolId(2020L).setPermissionSetId(3333L).build();
+  private static final PoolAssignmentModel POOL_ASSIGNMENT_4 =
+      PoolAssignmentModel.builder().setCasePoolId(2020L).setPermissionSetId(4444L).build();
+
+  private static final UserModel USER_0 =
+      UserModel.builder()
+          .setUserId(0L)
+          .setWorkforceId(1033L)
+          .setWorkgroupId(0L)
+          .setRoleIds(ImmutableList.of(1111L, 2222L, 4444L))
+          .setSkillIds(ImmutableList.of())
+          .setRoleSkillIds(ImmutableList.of())
+          .setPoolAssignments(ImmutableSet.of())
+          .build();
+
+  private static final UserModel USER_1 =
+      UserModel.builder()
+          .setUserId(1L)
+          .setWorkforceId(1034L)
+          .setWorkgroupId(0L)
+          .setRoleIds(ImmutableList.of())
+          .setSkillIds(ImmutableList.of())
+          .setRoleSkillIds(ImmutableList.of())
+          .setPoolAssignments(ImmutableSet.of())
+          .build();
+
+  private static final UserModel USER_2 =
+      UserModel.builder()
+          .setUserId(2L)
+          .setWorkforceId(1033L)
+          .setWorkgroupId(2020L)
+          .setRoleIds(ImmutableList.of(1111L, 2222L, 4444L))
+          .setSkillIds(ImmutableList.of(1111L, 2222L))
+          .setRoleSkillIds(ImmutableList.of(3333L))
+          .setPoolAssignments(ImmutableSet.of(POOL_ASSIGNMENT_0, POOL_ASSIGNMENT_1))
+          .build();
+
+  private static final UserModel USER_3 =
+      UserModel.builder()
+          .setUserId(3L)
+          .setWorkforceId(1033L)
+          .setWorkgroupId(2020L)
+          .setRoleIds(ImmutableList.of(1111L))
+          .setSkillIds(ImmutableList.of(1111L, 2222L))
+          .setRoleSkillIds(ImmutableList.of(3333L))
+          .setPoolAssignments(
+              ImmutableSet.of(POOL_ASSIGNMENT_0, POOL_ASSIGNMENT_2, POOL_ASSIGNMENT_3))
+          .build();
+
+  private static final UserModel USER_4 =
+      UserModel.builder()
+          .setUserId(4L)
+          .setWorkforceId(1033L)
+          .setWorkgroupId(2022L)
+          .setRoleIds(ImmutableList.of(1111L))
+          .setSkillIds(ImmutableList.of(1111L, 2222L))
+          .setRoleSkillIds(ImmutableList.of(3333L))
+          .setPoolAssignments(
+              ImmutableSet.of(POOL_ASSIGNMENT_0, POOL_ASSIGNMENT_2, POOL_ASSIGNMENT_3))
+          .build();
+
+  private static final UserModel USER_5 =
+      UserModel.builder()
+          .setUserId(5L)
+          .setWorkforceId(1033L)
+          .setWorkgroupId(2020L)
+          .setRoleIds(ImmutableList.of(1111L))
+          .setSkillIds(ImmutableList.of(1111L, 2222L))
+          .setRoleSkillIds(ImmutableList.of(3333L))
+          .setPoolAssignments(ImmutableSet.of(POOL_ASSIGNMENT_0, POOL_ASSIGNMENT_4))
+          .build();
+
+  private static final UserModel USER_6 =
+      UserModel.builder()
+          .setUserId(6L)
+          .setWorkforceId(1033L)
+          .setWorkgroupId(2020L)
+          .setRoleIds(ImmutableList.of(1111L, 2222L))
+          .setSkillIds(ImmutableList.of(1111L))
+          .setRoleSkillIds(ImmutableList.of())
+          .setPoolAssignments(ImmutableSet.of(POOL_ASSIGNMENT_0, POOL_ASSIGNMENT_1))
+          .build();
+
+  private static final ImmutableList<UserModel> INPUT_USERS_INCLUDE_INVALID_WORKGROUP_ID =
+      ImmutableList.of(USER_0, USER_1, USER_2, USER_3, USER_4, USER_5, USER_6);
+
+  private static final ImmutableList<UserModel> EXPECTED_USERS_WITH_VALID_WORKGROUP_ID =
+      ImmutableList.of(USER_2, USER_3, USER_4, USER_5, USER_6);
+
+  private static final int EXPECTED_NUMBER_OF_USERS_USERS_WITH_VALID_WORKGROUP_ID = 5;
+
+  private static final ImmutableList<UserModel> INPUT_USERS_INCLUDE_CONFLICTS =
+      ImmutableList.of(USER_2, USER_3, USER_4, USER_5, USER_6);
+
+  private static final ImmutableList<UserModel> EXPECTED_USERS_WITHOUT_CONFLICTS =
+      ImmutableList.of(USER_2, USER_4, USER_6);
+
+  private static final int EXPECTED_NUMBER_OF_USERS_USERS_WITHOUT_CONFLICTS = 3;
+
+  private static final int EXPECTED_NUMBER_OF_USERS_USERS_WITH_EMPTY_INPUT = 0;
 
   @Test
-  public void filterInvalidTest() throws IOException, CsvException {
-    ImmutableList<UserModel> userPoolAssignments =
-        CsvParser.readFromCSVFile(TEST_CSV_FILE_PATH);
-    ImmutableList<UserModel> validUserPoolAssignments =
-        DataProcessor.filterValidData(userPoolAssignments);
-    Assert.assertEquals(EXPECTED_VALID_DATA_SIZE, 5);
-    for (UserModel userData : validUserPoolAssignments) {
-      Assert.assertNotEquals(INVALID_WORKGROUP_ID, userData.workgroupId());
-    }
+  public void filterInvalidWorkgroupIdTest() {
+    ImmutableList<UserModel> validUsers =
+        DataProcessor.filterUsersWithValidWorkgroupId(INPUT_USERS_INCLUDE_INVALID_WORKGROUP_ID);
+    Assert.assertEquals(EXPECTED_NUMBER_OF_USERS_USERS_WITH_VALID_WORKGROUP_ID, validUsers.size());
+    Assert.assertTrue(validUsers.equals(EXPECTED_USERS_WITH_VALID_WORKGROUP_ID));
+  }
+
+  @Test
+  public void filterInvalidWorkgroupIdWithEmptyInputTest() {
+    ImmutableList<UserModel> validUsers =
+        DataProcessor.filterUsersWithValidWorkgroupId(ImmutableList.of());
+    Assert.assertEquals(EXPECTED_NUMBER_OF_USERS_USERS_WITH_EMPTY_INPUT, validUsers.size());
+    Assert.assertTrue(validUsers.equals(ImmutableList.of()));
+  }
+
+  @Test
+  public void filterConflictDataTest() {
+    ImmutableList<UserModel> validUsers =
+        DataProcessor.removeConflictUsers(INPUT_USERS_INCLUDE_CONFLICTS);
+    Assert.assertEquals(EXPECTED_NUMBER_OF_USERS_USERS_WITHOUT_CONFLICTS, validUsers.size());
+    Assert.assertTrue(validUsers.equals(EXPECTED_USERS_WITHOUT_CONFLICTS));
+  }
+
+  @Test
+  public void filterConflictDataWithEmptyInputTest() {
+    ImmutableList<UserModel> validUsers = DataProcessor.removeConflictUsers(ImmutableList.of());
+    Assert.assertEquals(EXPECTED_NUMBER_OF_USERS_USERS_WITH_EMPTY_INPUT, validUsers.size());
+    Assert.assertTrue(validUsers.equals(ImmutableList.of()));
   }
 }


### PR DESCRIPTION
#20 

1. Add functions in Data Processor class

- Check for conflict user pairs

- Remove conflict users

2. Add Flag `assignMorePermissions` flag to the `RuleSuggestionService` interface.

- `assignMorePermissions` flag is used to control whether we want the final generated rules to assign more permissions or less permissions in conflict cases.

3. Remove the `percentage` int variable in the `RuleSuggestionService` interface.
4. Update tests

Results for removing conflict users:

- Origin data set: 97.67%
- New data set: 99.50%