### PR TITLE
Bugs in Removing Conflict Users

### DIFF
--- a/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
@@ -41,19 +41,16 @@ public class DataProcessor {
 
   private static ImmutableSet<Long> findConflictUserIdPairs(List<UserModel> rawUserData) {
     Set<Long> dirtyUsers = new HashSet<Long>();
-    Set<Long> visitedUsers = new HashSet<Long>();
 
     for (UserModel currentUser : rawUserData) {
       if (dirtyUsers.contains(currentUser.userId())) {
         continue;
       }
-      visitedUsers.add(currentUser.userId());
       dirtyUsers.addAll(
           rawUserData.stream()
               .filter(
                   comparedUser ->
-                      !visitedUsers.contains(comparedUser.userId())
-                          && !dirtyUsers.contains(comparedUser.userId())
+                      !dirtyUsers.contains(comparedUser.userId())
                           && currentUser.isConflictUserPair(comparedUser))
               .map(UserModel::userId)
               .collect(toSet()));

--- a/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/action/DataProcessor.java
@@ -51,7 +51,7 @@ public class DataProcessor {
               .filter(
                   comparedUser ->
                       !dirtyUsers.contains(comparedUser.userId())
-                          && currentUser.isConflictUserPair(comparedUser))
+                          && currentUser.isAConflictUser(comparedUser))
               .map(UserModel::userId)
               .collect(toSet()));
     }

--- a/src/main/java/com/googleintern/wfm/ruleengine/model/UserModel.java
+++ b/src/main/java/com/googleintern/wfm/ruleengine/model/UserModel.java
@@ -53,7 +53,7 @@ public abstract class UserModel {
     public abstract UserModel build();
   }
 
-  public boolean isConflictUserPair(UserModel comparedUser) {
+  public boolean isAConflictUser(UserModel comparedUser) {
     return workforceId() == comparedUser.workforceId()
         && workgroupId() == comparedUser.workgroupId()
         && skillIds().containsAll(comparedUser.skillIds())

--- a/src/test/java/com/googleintern/wfm/ruleengine/DataProcessorTest.java
+++ b/src/test/java/com/googleintern/wfm/ruleengine/DataProcessorTest.java
@@ -108,8 +108,11 @@ public class DataProcessorTest {
 
   private static final int EXPECTED_NUMBER_OF_USERS_USERS_WITH_VALID_WORKGROUP_ID = 5;
 
-  private static final ImmutableList<UserModel> INPUT_USERS_INCLUDE_CONFLICTS =
+  private static final ImmutableList<UserModel> INPUT_USERS_INCLUDE_CONFLICTS_1 =
       ImmutableList.of(USER_3, USER_2, USER_4, USER_5, USER_6);
+
+  private static final ImmutableList<UserModel> INPUT_USERS_INCLUDE_CONFLICTS_2 =
+      ImmutableList.of(USER_2, USER_3, USER_4, USER_5, USER_6);
 
   private static final ImmutableList<UserModel> EXPECTED_USERS_WITHOUT_CONFLICTS =
       ImmutableList.of(USER_2, USER_4, USER_6);
@@ -135,9 +138,17 @@ public class DataProcessorTest {
   }
 
   @Test
-  public void filterConflictDataTest() {
+  public void filterConflictDataTest_Case1() {
     ImmutableList<UserModel> validUsers =
-        DataProcessor.removeConflictUsers(INPUT_USERS_INCLUDE_CONFLICTS);
+        DataProcessor.removeConflictUsers(INPUT_USERS_INCLUDE_CONFLICTS_1);
+    Assert.assertEquals(EXPECTED_NUMBER_OF_USERS_USERS_WITHOUT_CONFLICTS, validUsers.size());
+    Assert.assertTrue(validUsers.equals(EXPECTED_USERS_WITHOUT_CONFLICTS));
+  }
+
+  @Test
+  public void filterConflictDataTest_Case2(){
+    ImmutableList<UserModel> validUsers =
+            DataProcessor.removeConflictUsers(INPUT_USERS_INCLUDE_CONFLICTS_2);
     Assert.assertEquals(EXPECTED_NUMBER_OF_USERS_USERS_WITHOUT_CONFLICTS, validUsers.size());
     Assert.assertTrue(validUsers.equals(EXPECTED_USERS_WITHOUT_CONFLICTS));
   }

--- a/src/test/java/com/googleintern/wfm/ruleengine/DataProcessorTest.java
+++ b/src/test/java/com/googleintern/wfm/ruleengine/DataProcessorTest.java
@@ -109,7 +109,7 @@ public class DataProcessorTest {
   private static final int EXPECTED_NUMBER_OF_USERS_USERS_WITH_VALID_WORKGROUP_ID = 5;
 
   private static final ImmutableList<UserModel> INPUT_USERS_INCLUDE_CONFLICTS =
-      ImmutableList.of(USER_2, USER_3, USER_4, USER_5, USER_6);
+      ImmutableList.of(USER_3, USER_2, USER_4, USER_5, USER_6);
 
   private static final ImmutableList<UserModel> EXPECTED_USERS_WITHOUT_CONFLICTS =
       ImmutableList.of(USER_2, USER_4, USER_6);


### PR DESCRIPTION
Find a bug in finding conflict users in the data processor class:

- We cannot use visited set to store all users we checked and skill these user when we finding conflict pairs. 
[Example]
User 0 = {skill_ids: 1111, 2222}, {role_ids: 3333}, {permissions = aaaa, bbbb}
User 1 = {skill_ids: 1111, 2222}, {role_ids: 3333, 4444}, {permissions = aaaa}

The `isAConflictUser` function in UserModel class will return true for this case. Then User 0 adds to visited set. When we check for User 1, the program will skip User 0 buz it is visited. However, User 0 is conflict with User 1 and should be deleted. 